### PR TITLE
Add comprehensive auto-updater notifications with version display

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -271,19 +271,31 @@ class MenuBarNotificationApp {
 
         // Auto-updater event handlers
         autoUpdater.on('checking-for-update', () => {
-
+          console.log('Checking for updates...')
         })
 
-        autoUpdater.on('update-available', () => {
-          console.log('Update available')
+        autoUpdater.on('update-available', (info: { version: string, releaseDate?: string, releaseName?: string, releaseNotes?: string }) => {
+          console.log('Update available:', info)
+          // Send update info to renderer process
+          this.windowManager.sendMessage('update-available', info)
         })
 
         autoUpdater.on('update-not-available', () => {
-
+          console.log('No updates available')
         })
 
-        autoUpdater.on('update-downloaded', () => {
-          // Notify user and ask if they want to restart
+        autoUpdater.on('download-progress', (progressObj: { bytesPerSecond: number, percent: number, transferred: number, total: number }) => {
+          console.log('Download progress:', progressObj)
+          // Send download progress to renderer process
+          this.windowManager.sendMessage('download-progress', progressObj)
+        })
+
+        autoUpdater.on('update-downloaded', (info: { version: string, releaseDate?: string, releaseName?: string, releaseNotes?: string }) => {
+          console.log('Update downloaded:', info)
+          // Send update downloaded event to renderer process
+          this.windowManager.sendMessage('update-downloaded', info)
+
+          // Also show native notification as backup
           const notification = new Notification({
             title: 'Update Ready',
             body: 'A new version has been downloaded. Restart now to apply the update?',
@@ -2005,6 +2017,10 @@ class MenuBarNotificationApp {
 
     ipcMain.handle('get-version-install-date', async (): Promise<Date | null> => {
       return await this.getCurrentVersionInstallDate()
+    })
+
+    ipcMain.handle('get-app-version', (): string => {
+      return app.getVersion()
     })
 
     ipcMain.handle('logout', (): void => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -233,6 +233,9 @@ export interface ElectronAPI {
 
   // Version install date
   getVersionInstallDate: () => Promise<Date | null>
+
+  // App version
+  getAppVersion: () => Promise<string>
 }
 
 // Expose protected methods that allow the renderer process to use
@@ -411,6 +414,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Version install date
   getVersionInstallDate: (): Promise<Date | null> => ipcRenderer.invoke('get-version-install-date'),
+
+  // App version
+  getAppVersion: (): Promise<string> => ipcRenderer.invoke('get-app-version'),
 } as ElectronAPI)
 
 // Extend the global Window interface

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -17,6 +17,7 @@ import { ApprovalScreen } from './components/screens/ApprovalPanel'
 import OnboardingView from './components/screens/onboarding/OnboardingView'
 import { SettingsScreen } from './components/screens/settings/SettingsScreen'
 import { Share } from './components/Share'
+import { UpdateNotification } from './components/UpdateNotification'
 import { Badge } from './components/ui/badge'
 import { Button } from './components/ui/button'
 import { ButtonDesigned } from './components/ui/ButtonDesigned'
@@ -971,6 +972,9 @@ const AppContent: React.FC = () => {
             )
           : getMessageScreen()}
       </div>
+
+      {/* Auto-update notifications */}
+      <UpdateNotification />
     </div>
   )
 }

--- a/src/renderer/components/screens/settings/panels/AdvancedPanel.tsx
+++ b/src/renderer/components/screens/settings/panels/AdvancedPanel.tsx
@@ -4,6 +4,8 @@ import Toggle from '../../../ui/Toggle'
 export const AdvancedPanel: React.FC = () => {
   const [fullCodeExecution, setFullCodeExecution] = useState(false)
   const [fullCodeExecutionDisabled, setFullCodeExecutionDisabled] = useState(true)
+  const [appVersion, setAppVersion] = useState<string>('Loading...')
+  const [installDate, setInstallDate] = useState<Date | null>(null)
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   const loadFullCodeExecutionSetting = async () => {
@@ -34,6 +36,21 @@ export const AdvancedPanel: React.FC = () => {
 
   useEffect(() => {
     loadFullCodeExecutionSetting()
+
+    // Load app version
+    window.electronAPI.getAppVersion().then(version => {
+      setAppVersion(version)
+    }).catch(error => {
+      console.error('Failed to get app version:', error)
+      setAppVersion('Unknown')
+    })
+
+    // Load install date
+    window.electronAPI.getVersionInstallDate().then(date => {
+      setInstallDate(date)
+    }).catch(error => {
+      console.error('Failed to get install date:', error)
+    })
   }, [])
 
   return (
@@ -74,6 +91,30 @@ export const AdvancedPanel: React.FC = () => {
               onChange={handleChangeFullCodeExecutionSetting}
             />
           </div>
+        </div>
+      </div>
+
+      {/* Version Information */}
+      <div
+        className="p-[0.94rem] border border-[#E5E5E5] rounded-[0.38rem] flex flex-col gap-[0.63rem]"
+      >
+        <div className="font-semibold">
+          Version Information
+        </div>
+        <div className="flex flex-col gap-[0.38rem]">
+          <div className="flex justify-between items-center">
+            <span className="text-[#737373]">Current Version:</span>
+            <span className="font-mono">{appVersion}</span>
+          </div>
+          {installDate && (
+            <div className="flex justify-between items-center">
+              <span className="text-[#737373]">Installed:</span>
+              <span className="text-sm">{installDate.toLocaleString()}</span>
+            </div>
+          )}
+        </div>
+        <div className="text-xs text-[#737373] mt-2">
+          The app automatically checks for updates. You'll be notified when a new version is available.
         </div>
       </div>
     </div>


### PR DESCRIPTION
This commit enhances the auto-updater functionality by integrating consistent notifications throughout the application:

- Main process now sends update events to renderer (update-available, download-progress, update-downloaded)
- Integrated existing UpdateNotification component into App.tsx for consistent toast-style notifications
- Added version display in Settings > Advanced panel showing current version and install date
- Added getAppVersion IPC handler and preload API method
- Notifications use Shadcn components for consistent UI/UX
- Users can trigger updates directly from notifications or view version info in settings

The notification system provides clear feedback for:
- Update available (with download button)
- Download progress (with percentage and speed)
- Update ready to install (with restart button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)