### PR TITLE
Fix SSE disconnect on WebSocket disconnect

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2374,11 +2374,6 @@ class MenuBarNotificationApp {
       if (this.executorWSClient) {
         this.executorWSClient.disconnect()
       }
-      
-      // Disconnect from SSE when executor disconnects
-      if (this.sseBackgroundService) {
-        this.sseBackgroundService.disconnect()
-      }
     })
 
     // Codespace discovery and management IPC handlers


### PR DESCRIPTION
Removed the logic that was disconnecting the SSE connection when disconnecting from the executor WebSocket. The SSE connection should remain active to continue receiving codespace online/offline events even when the WebSocket is disconnected.

Fixed in disconnect-from-executor IPC handler (main.ts:2373-2377)

🤖 Generated with [Claude Code](https://claude.com/claude-code)